### PR TITLE
Connect Rolodex Angular to Sprockets

### DIFF
--- a/lib/rolodex.rb
+++ b/lib/rolodex.rb
@@ -5,6 +5,7 @@ module Rolodex
 
   if defined?(::Middleman)
     require "middleman-autoprefixer"
+    require "rolodex/sprockets"
   end
 
 end

--- a/lib/rolodex/sprockets.rb
+++ b/lib/rolodex/sprockets.rb
@@ -1,0 +1,3 @@
+require 'sprockets'
+
+Sprockets.append_path File.expand_path("../../vendor/assets/javascripts")

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "karma-safari-launcher": "^0.1.1"
   },
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start"
+    "test_angular": "./node_modules/karma/bin/karma start"
   },
   "repository": {
     "type": "git",

--- a/vendor/assets/javascripts/rolodex_angular.coffee
+++ b/vendor/assets/javascripts/rolodex_angular.coffee
@@ -1,0 +1,1 @@
+#= require 'rolodex_angular/rolodex'

--- a/vendor/assets/javascripts/rolodex_angular/README.md
+++ b/vendor/assets/javascripts/rolodex_angular/README.md
@@ -1,0 +1,68 @@
+# [Angular](https://angularjs.org/) modules just for [Rolodex](https://github.com/bellycard/rolodex)
+
+***
+
+## Wat?
+Rolodex components written in Angular. Rolodex Angular has very few dependencies, requiring only [AngularJS](https://angularjs.org/), of course, and [LoDash](http://lodash.com/) (or [Underscore](http://underscorejs.org/)). The collection of directives should be very simple to use, fast, and drop in seamlessly when using Rolodex styles and classes. jQuery is not required for any of these modules to work now and forever. This project is heavily infulenced by [UI Bootstrap](http://angular-ui.github.io/bootstrap/).
+
+## See Rolodex Angular In Action
+[Belly Style Guide](https://style.bellycard.com/)
+
+## Installation
+Required libraries
+
+* [AngularJS](https://angularjs.org/)
+* [LoDash](http://lodash.com/) or [Underscore](http://underscorejs.org/)
+
+Make sure that both are loaded before Rolodex.
+
+Add to your `Gemfile:`
+
+```ruby
+gem 'rolodex', :git => 'https://github.com/bellycard/rolodex.git'
+```
+
+Import to your main coffee/js file
+
+```coffeescript
+#= require 'rolodex_angular'
+```
+
+Add Rolodex to your Angular App
+
+```coffeescript
+angular.module('myApp', ['rolodex'])
+```
+
+## Dial Up Only What You Need
+Utilizing Angular's flexible module system each directive is its own module which means you don't have to import then entire rolodex module if you don't need it. No need for jQuery either - each module should be independent of jQuery. Guaranteed. Forever.
+
+## Tested Browsers
+* Chrome
+* Safari
+* IE 9/10
+* Opera
+
+## Development
+You will need already installed:
+
+* Ruby
+* NodeJS (For Karma, the test runner)
+
+Run Bundler
+
+```
+$: bundle install
+```
+
+Run NPM install
+
+```
+$: npm install
+```
+
+Run Karma
+
+```
+$: npm test_angular
+```


### PR DESCRIPTION
Have Sprockets load up Rolodex Angular. The way this is loaded is intended to allow for a future Rolodex jQuery version. Update README with some basic info as to what this collection of modules is and how to use it.

Sample usage of how loading Rolodex Angular vs jQuery would work

``` coffeescript
#= require 'rolodex_angular'
#= require 'rolodex_jquery'
```

@shayhowe #coderetreat
