### PR TITLE
Let Rolodex create the Angular template cache

### DIFF
--- a/lib/rolodex.rb
+++ b/lib/rolodex.rb
@@ -9,7 +9,7 @@ module Rolodex
     require "rolodex/sprockets"
 
     Angular::Html2js.configure do |config|
-      config.module_name = 'rolodexTemplates'
+      config.module_name = 'templates'
       config.init_sprockets
     end
 

--- a/vendor/assets/javascripts/rolodex_angular/rolodex.coffee
+++ b/vendor/assets/javascripts/rolodex_angular/rolodex.coffee
@@ -1,6 +1,6 @@
 # Initialize primary namespace
 angular.module('rolodex', [
-  'rolodexTemplates'
+  'templates'
   'rolodex.buttons'
   'rolodex.dropdown'
   'rolodex.modal'

--- a/vendor/assets/javascripts/rolodex_angular/src/modal.coffee
+++ b/vendor/assets/javascripts/rolodex_angular/src/modal.coffee
@@ -5,7 +5,7 @@
 # work with the Rolodex styles. The rest remains true to the Bootstrap source including using their transition
 # animation library and not ngAnimate.
 
-angular.module("rolodex.modal", ["rolodex.transition", "rolodexTemplates"])
+angular.module("rolodex.modal", ["rolodex.transition", "templates"])
 
 # A helper, internal data structure that acts as a map but also allows getting / removing
 # elements in the LIFO order


### PR DESCRIPTION
Apps that use Rolodex will then not have to set up the Angular html2js template cache it will just be available app wide as 'template' and .ngt.haml will just work out of the box. Otherwise separating template caches wont really work because of how the Angular html2js gem works. Long term the logic from the Angular html2js gem should be built directly into Rolodex allow for more flexibility when working with template caches.

@shayhowe @darbyfrey #coderetreat
