### PR TITLE
Remove autoprefixer

### DIFF
--- a/lib/rolodex.rb
+++ b/lib/rolodex.rb
@@ -7,9 +7,5 @@ module Rolodex
     config.module_name = 'templates'
     config.init_sprockets
   end
-  
-  if defined?(::Middleman)
-    require "middleman-autoprefixer"
-  end
 
 end

--- a/lib/rolodex.rb
+++ b/lib/rolodex.rb
@@ -2,10 +2,30 @@ require 'angular/html2js'
 require 'rolodex/sass'
 
 module Rolodex
+  class << self
+    # Inspired by bootstrap-sass
+    def load!
+      Angular::Html2js.configure do |config|
+        config.module_name = 'templates'
+        config.init_sprockets
+      end
 
-  Angular::Html2js.configure do |config|
-    config.module_name = 'templates'
-    config.init_sprockets
+      if defined?(::Rails)
+        require 'rolodex/engine'
+      elsif defined?(:Sprockets)
+        Sprockets.append_path(File.join(asset_path, 'stylesheets'))
+        Sprockets.append_path(File.join(asset_path, 'javascripts'))
+      end
+    end
+
+    def gem_path
+      @gem_path ||= File.expand_path '..', File.dirname(__FILE__)
+    end
+
+    def asset_path
+      @asset_path ||= File.join gem_path, 'vendor', 'assets'
+    end
   end
-
 end
+
+Rolodex.load!

--- a/lib/rolodex/engine.rb
+++ b/lib/rolodex/engine.rb
@@ -1,0 +1,12 @@
+module Rolodex
+  module Rails
+    class Engine < ::Rails::Engine
+      initializer 'rolodex.assets.precompile' do |app|
+        %w(stylesheets javascripts images).each do |sub|
+          app.config.assets.paths << root.join('vendor', 'assets', sub).to_s
+        end
+        app.config.assets.precompile << %r(\.(?:png|svg|gif)$)
+      end
+    end
+  end
+end

--- a/lib/rolodex/sass.rb
+++ b/lib/rolodex/sass.rb
@@ -1,3 +1,5 @@
+require 'sass'
+
 # Rounding numbers to the 8th decimal
 
 Sass::Script::Number.precision = 8

--- a/rolodex.gemspec
+++ b/rolodex.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'angular-html2js'
-  spec.add_dependency 'middleman-autoprefixer'
   spec.add_dependency 'sass', '~> 3.4.3'
   spec.add_dependency 'sprockets', '~> 2.12.2'
 

--- a/vendor/assets/stylesheets/rolodex/base/_typography.sass
+++ b/vendor/assets/stylesheets/rolodex/base/_typography.sass
@@ -20,7 +20,7 @@ html
 
 // Margins
 
-#{headings()},
+#{map-keys($headings)},
 p
   @extend %margin-0
   @extend %margin-bottom


### PR DESCRIPTION
@bellycard/apps If all is well, this should make rolodex work with rails apps!  Wooh!

@shayhowe most of this is just behind-the-scenes stuff with the Gem. I tested it both in WCC (middleman) and Sherpa (Rails), and everything works as expected.

There is one SASS change that you should take a look at. You were using the `headings()` function inside of the typography file. `headings()` is a compass function, which we are not using anymore. I'm not sure why this hasn't caused issues in the past - perhaps all of our RoloD projects conveniently have Compass required as well - but it was breaking when Rails tried to compile the SASS.

I translated

```
#{headings()},
```

to

```
#{map-keys($headings)},
```

which seems to do the same thing. Let me know if that works or not.
