### PR TITLE
uses green for success, not blue

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rolodex",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "homepage": "http://bellycard.com/",
   "repository": {
     "type": "git",

--- a/lib/rolodex/version.rb
+++ b/lib/rolodex/version.rb
@@ -1,3 +1,3 @@
 module Rolodex
-  VERSION = "2.0.1"
+  VERSION = "2.0.2"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rolodex",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Style for Belly",
   "main": "",
   "dependencies": {},

--- a/vendor/assets/stylesheets/rolodex/settings/variables/_typography.scss
+++ b/vendor/assets/stylesheets/rolodex/settings/variables/_typography.scss
@@ -28,7 +28,7 @@ $font-family-monospace: "Source Code Pro", Inconsolata, "Lucida Console", Termin
 
 $text-colors: (
   $gray: subtle,
-  $blue: success,
+  $green: success,
   $gold: warning,
   $red:  danger
 );


### PR DESCRIPTION
@shayhowe not sure if this is even a thing, but I was looking through https://style.bellycard.com/#nav-typography and noticed that the `.text-success` utility class was blue, but I think it should be green. If this is intentional, feel free to close the PR. If not, I think this will fix it. 

![screen shot 2015-06-12 at 3 16 21 pm](https://cloud.githubusercontent.com/assets/1316075/8139147/ebba7314-1116-11e5-8d57-e7112cf2a3a9.png)
