### PR TITLE
fix for dropdown selects

### DIFF
--- a/vendor/assets/javascripts/rolodex_angular/src/dropdown.coffee
+++ b/vendor/assets/javascripts/rolodex_angular/src/dropdown.coffee
@@ -4,7 +4,8 @@ angular.module('rolodex.dropdown', [])
 
 .service('dropdownService', [
   '$document'
-  ($document) ->
+  '$timeout'
+  ($document, $timeout) ->
     openScope = null
 
     @open = (dropdownScope) ->
@@ -20,6 +21,9 @@ angular.module('rolodex.dropdown', [])
 
         if dropdownScope.forceClose
           openScope.isOpen = false if openScope
+
+          $timeout ->
+            dropdownScope.isOpen = false
 
         openScope = null
         $document.unbind 'click', closeDropdown


### PR DESCRIPTION
when using the dropdown component as a select box (dropdown-select), clicking on a dropdown-menu-item doesn't trigger the menu to close.

the `dropdown-select` component doesn't use openScope directly, so an additional call must be made for the isOpen to propagate to the right scope.

the $timeout ensures there isnt any digest problems with the openScope close call

definitely open to an alternative solution to this
