### PR TITLE
bump to most recent version of sprockets so we can use es6

### DIFF
--- a/rolodex.gemspec
+++ b/rolodex.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'angular-html2js'
   spec.add_dependency 'sass', '~> 3.4.3'
-  spec.add_dependency 'sprockets', '~> 2.12.2'
+  spec.add_dependency 'sprockets'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
@bellycard/apps 

Updating sprockets dependency so we can use the latest version `3.5.2`

```
Bundler could not find compatible versions for gem "sprockets":
  In Gemfile:
    sass-rails (~> 5.0) ruby depends on
      sprockets (< 4.0, >= 2.8) ruby

    sass-rails (~> 5.0) ruby depends on
      sprockets-rails (< 4.0, >= 2.0) ruby depends on
        sprockets (>= 3.0.0) ruby

    rolodex (>= 0) ruby depends on
      sprockets (~> 2.12.2) ruby
```
