### PR TITLE
A replacement for input stepper

### DIFF
--- a/vendor/assets/javascripts/rolodex_angular/rolodex.coffee
+++ b/vendor/assets/javascripts/rolodex_angular/rolodex.coffee
@@ -8,4 +8,5 @@ angular.module('rolodex', [
   'rolodex.dropdown'
   'rolodex.modal'
   'rolodex.transition'
+  'rolodex.stepper'
 ])

--- a/vendor/assets/javascripts/rolodex_angular/src/stepper.coffee
+++ b/vendor/assets/javascripts/rolodex_angular/src/stepper.coffee
@@ -1,6 +1,6 @@
 #= require 'rolodex_angular/template/stepper/stepper'
 
-angular.module 'bly.components.stepper', []
+angular.module 'rolodex.stepper', []
 
 .directive 'blyStepper', ->
   restrict: 'AE'

--- a/vendor/assets/javascripts/rolodex_angular/src/stepper.coffee
+++ b/vendor/assets/javascripts/rolodex_angular/src/stepper.coffee
@@ -1,0 +1,71 @@
+#= require 'rolodex_angular/template/stepper/stepper'
+
+angular.module 'bly.components.stepper', []
+
+.directive 'blyStepper', ->
+  restrict: 'AE'
+  require: 'ngModel'
+  scope:
+    min: '@'
+    max: '@'
+    step: '@'
+    name: '@'
+    ngModel: '='
+    ngDisabled: '='
+  templateUrl: 'rolodex_angular/template/stepper/stepper'
+
+  link: (scope, elem, attrs, ngModelCtrl) ->
+    scope.step = 1 unless scope.step
+    scope.min = _.parseInt(scope.min) if scope.min
+    scope.max = _.parseInt(scope.max) if scope.max
+
+    # On input and increment/decrement, turn the string into an integer
+    ngModelCtrl.$formatters.push (value) -> _.parseInt(value)
+    ngModelCtrl.$parsers.push (value) -> _.parseInt(value)
+
+    # Update the value
+    updateViewValue = (value) ->
+      ngModelCtrl.$setViewValue(_.parseInt(value))
+      ngModelCtrl.$render()
+      scope.$emit('stepper:update', value)
+
+    # Decrement the value if:
+    #   a min value is defined, and the value is >= the min
+    #   you wont go below the min value if you decrement by the step
+    scope.canDecrement = ->
+      return true unless scope.min
+
+      angular.isDefined(scope.min) and
+        ngModelCtrl.$viewValue >= scope.min and
+        (ngModelCtrl.$viewValue + -scope.step) >= scope.min
+
+    # Increment the value if:
+    #   a max value is defined, and the value is <= the max
+    #   you wont go above the max value if you increment by the step
+    scope.canIncrement = ->
+      return true unless scope.max
+
+      angular.isDefined(scope.max) and
+        ngModelCtrl.$viewValue <= scope.max
+        (ngModelCtrl.$viewValue + +scope.step) <= scope.max
+
+    # Increment the value by the step
+    scope.increment = ->
+      value = ngModelCtrl.$viewValue + +scope.step
+      updateViewValue(value)
+      scope.$emit('stepper:increment', value)
+
+    # Decrement the value by the step
+    scope.decrement = ->
+      value = ngModelCtrl.$viewValue + -scope.step
+      updateViewValue(value)
+      scope.$emit('stepper:decrement', value)
+
+    elem.find('input').bind 'blur', ->
+      # If user clears the field, set it to 0
+      if isNaN(ngModelCtrl.$viewValue)
+        updateViewValue(scope.min)
+
+      # Remove leading zeroes when blurring
+      scope.$apply ->
+        scope.ngModel = _.parseInt(ngModelCtrl.$modelValue)

--- a/vendor/assets/javascripts/rolodex_angular/template/stepper/stepper.ngt
+++ b/vendor/assets/javascripts/rolodex_angular/template/stepper/stepper.ngt
@@ -1,0 +1,5 @@
+<input name="{{name}}" type="number" ng-model="ngModel" min="{{min}}" placeholder="{{min}}" >
+<div class="stepper">
+  <div class="btn-decrement" ng-disabled="!canDecrement()" ng-click="canDecrement() && decrement()">&ndash;</div>
+  <div class="btn-increment" ng-disabled="!canIncrement()" ng-click="canIncrement() && increment()">+</div>
+</div>

--- a/vendor/assets/stylesheets/rolodex/components/_stepper.sass
+++ b/vendor/assets/stylesheets/rolodex/components/_stepper.sass
@@ -1,0 +1,58 @@
+$stepper-button-height: 18px !default
+$stepper-button-width: 30px !default
+$stepper-padding: $baseline-step ($stepper-button-width + 10) $baseline-step 10px !default
+
+[bly-stepper]
+  +rem(border, 1px solid $gray-light)
+  border-radius: $border-radius-base
+  box-sizing: border-box
+  display: inline-block
+  +group
+  position: relative
+  +rem(width, 94px)
+
+  .btn-increment,
+  .btn-decrement
+    background: $white-offset
+    +rem(border-bottom, 1px solid $gray-light)
+    +rem(border-left, 1px solid $gray-light)
+    +rem(border-top-right-radius, $border-radius-base)
+    color: #000
+    cursor: pointer
+    +s-foxtrot
+    +rem(height, $stepper-button-height)
+    +rem(line-height, $stepper-button-height)
+    right: 0
+    text-align: center
+    top: 0
+    outline: none
+    position: absolute
+    +rem(width, $stepper-button-width)
+    user-select: none
+
+    &:active
+      background: darken($white-offset, 2%)
+
+    &[disabled]
+      color: $gray
+
+  .btn-decrement
+    top: auto
+    bottom: 0
+    border-bottom: none
+    +rem(border-top-right-radius, 0)
+    +rem(border-bottom-right-radius, $border-radius-base)
+
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button
+    -webkit-appearance: none
+    margin: 0
+
+  input
+    border: none
+    +rem(border-radius, $border-radius-base)
+    +rem(padding, $stepper-padding)
+    width: 100%
+
+    &:focus
+      outline: none

--- a/vendor/assets/stylesheets/rolodex/components/_stepper.sass
+++ b/vendor/assets/stylesheets/rolodex/components/_stepper.sass
@@ -4,20 +4,20 @@ $stepper-padding: $baseline-step ($stepper-button-width + 10) $baseline-step 10p
 
 [bly-stepper]
   +rem(border, 1px solid $gray-light)
-  border-radius: $border-radius-base
+  +rem(border-radius, $border-radius-base)
   box-sizing: border-box
   display: inline-block
   +group
   position: relative
   +rem(width, 94px)
 
-  .btn-increment,
   .btn-decrement
+  .btn-increment,
     background: $white-offset
     +rem(border-bottom, 1px solid $gray-light)
     +rem(border-left, 1px solid $gray-light)
     +rem(border-top-right-radius, $border-radius-base)
-    color: #000
+    color: $black
     cursor: pointer
     +s-foxtrot
     +rem(height, $stepper-button-height)
@@ -37,11 +37,11 @@ $stepper-padding: $baseline-step ($stepper-button-width + 10) $baseline-step 10p
       color: $gray
 
   .btn-decrement
-    top: auto
     bottom: 0
     border-bottom: none
-    +rem(border-top-right-radius, 0)
     +rem(border-bottom-right-radius, $border-radius-base)
+    +rem(border-top-right-radius, 0)
+    top: auto
 
   input::-webkit-outer-spin-button,
   input::-webkit-inner-spin-button


### PR DESCRIPTION
![screen shot 2016-06-29 at 5 32 36 pm](https://cloud.githubusercontent.com/assets/163537/16471001/8eaec508-3e1f-11e6-870d-cd9f7e6828ff.png)

A nicer input stepper, used like so

```
 <div bly-stepper data-step="5" name="points" data-min="0" ng-model="points"></div>
```

This PR will require the `gulp` task to be run before releasing.

@shayhowe @DLavin23 
