### PR TITLE
Add bump shorthand to margin/padding, and hide mixin

### DIFF
--- a/assets/stylesheets/rolodex/settings/mixins/_layout.sass
+++ b/assets/stylesheets/rolodex/settings/mixins/_layout.sass
@@ -34,6 +34,15 @@
   &:after
     clear: both
 
+// Accessible alternative to display: none
+
+=hide
+  clip: rect(1px, 1px, 1px, 1px)
+  +rem(height, 1px)
+  overflow: hidden
+  position: absolute !important
+  +rem(width, 1px)
+
 // Center
 
 =center($alignment)

--- a/assets/stylesheets/rolodex/settings/utilities/lib/_hide.sass
+++ b/assets/stylesheets/rolodex/settings/utilities/lib/_hide.sass
@@ -2,11 +2,7 @@
 // ========================================
 
 .hide
-  clip: rect(1px, 1px, 1px, 1px)
-  +rem(height, 1px)
-  overflow: hidden
-  position: absolute !important
-  +rem(width, 1px)
+  +hide
 
 // Responsive hide from $breakpoints
 

--- a/assets/stylesheets/rolodex/settings/utilities/lib/_margin.sass
+++ b/assets/stylesheets/rolodex/settings/utilities/lib/_margin.sass
@@ -40,6 +40,14 @@
   +rem(margin-left, $gutter-half)
   +rem(margin-right, $gutter-half)
 
+// Bump
+
+.m-bump
+  +bump(margin, box)
+
+.m-bump-h
+  +bump(margin, baselines gutters-half)
+
 // Resets
 
 .m-0

--- a/assets/stylesheets/rolodex/settings/utilities/lib/_padding.sass
+++ b/assets/stylesheets/rolodex/settings/utilities/lib/_padding.sass
@@ -40,6 +40,14 @@
   +rem(padding-left, $gutter-half)
   +rem(padding-right, $gutter-half)
 
+// Bump
+
+.p-bump
+  +bump(padding, box)
+
+.p-bump-h
+  +bump(padding, baselines gutters-half)
+
 // Resets
 
 .p-0


### PR DESCRIPTION
Turned the bump mixin into a shorthand.

`box` defaults to `$baseline-base $gutter`. 
