### PR TITLE
Add responsive helpers for display/float

### DIFF
--- a/assets/stylesheets/rolodex.sass
+++ b/assets/stylesheets/rolodex.sass
@@ -17,6 +17,7 @@
 @import rolodex/components/dropdowns
 @import rolodex/components/forms
 @import rolodex/components/grid
+@import rolodex/components/grid-responsive
 @import rolodex/components/icons
 @import rolodex/components/lists
 @import rolodex/components/labels

--- a/assets/stylesheets/rolodex/components/_grid-responsive.sass
+++ b/assets/stylesheets/rolodex/components/_grid-responsive.sass
@@ -22,7 +22,7 @@ $columns: 12
 
       @for $column from 1 to $columns
 
-        .grid-#{$name}-#{$column}-#{$columns}
+        .grid-#{$column}-#{$columns}-#{$name}
           width: ($column/$columns) * 100%
 
   $columns: $columns - 1

--- a/assets/stylesheets/rolodex/settings/utilities/lib/_display.sass
+++ b/assets/stylesheets/rolodex/settings/utilities/lib/_display.sass
@@ -19,5 +19,5 @@ $displays: "block", "inline", "inline-block", "none", "table", "table-cell"
 
     @each $display in $displays
 
-      .d-#{$display}-#{$name}
+      .d-#{$name}-#{$display}
         display: #{$display}

--- a/assets/stylesheets/rolodex/settings/utilities/lib/_display.sass
+++ b/assets/stylesheets/rolodex/settings/utilities/lib/_display.sass
@@ -19,5 +19,5 @@ $displays: "block", "inline", "inline-block", "none", "table", "table-cell"
 
     @each $display in $displays
 
-      .d-#{$name}-#{$display}
+      .d-#{$display}-#{$name}
         display: #{$display}

--- a/assets/stylesheets/rolodex/settings/utilities/lib/_display.sass
+++ b/assets/stylesheets/rolodex/settings/utilities/lib/_display.sass
@@ -1,9 +1,23 @@
 // Display
 // ========================================
 
-$display: "block", "inline", "inline-block", "none", "table", "table-cell"
+$displays: "block", "inline", "inline-block", "none", "table", "table-cell"
 
-@each $value in $display
+@each $display in $displays
 
-  .d-#{$value}
-    display: #{$value}
+  .d-#{$display}
+    display: #{$display}
+
+// Responsive display
+
+@each $breakpoint in $breakpoints
+
+  $name:  nth($breakpoint, 1)
+  $value: nth($breakpoint, 2)
+
+  @media (min-width: $value)
+
+    @each $display in $displays
+
+      .d-#{$display}-#{$name}
+        display: #{$display}

--- a/assets/stylesheets/rolodex/settings/utilities/lib/_layout.sass
+++ b/assets/stylesheets/rolodex/settings/utilities/lib/_layout.sass
@@ -40,13 +40,13 @@
 
   @media (min-width: $value)
 
-    .f-left-#{$name}
+    .f-#{$name}-left
       display: left
 
-    .f-right-#{$name}
+    .f-#{$name}-right
       display: right
 
-    .f-none-#{$name}
+    .f-#{$name}-none
       display: none
 
 // Cursor

--- a/assets/stylesheets/rolodex/settings/utilities/lib/_layout.sass
+++ b/assets/stylesheets/rolodex/settings/utilities/lib/_layout.sass
@@ -31,6 +31,24 @@
 .f-none
   float: none
 
+// Responsive floats
+
+@each $breakpoint in $breakpoints
+
+  $name:  nth($breakpoint, 1)
+  $value: nth($breakpoint, 2)
+
+  @media (min-width: $value)
+
+    .f-left-#{$name}
+      display: left
+
+    .f-right-#{$name}
+      display: right
+
+    .f-none-#{$name}
+      display: none
+
 // Cursor
 
 .c-default

--- a/assets/stylesheets/rolodex/settings/utilities/lib/_layout.sass
+++ b/assets/stylesheets/rolodex/settings/utilities/lib/_layout.sass
@@ -40,13 +40,13 @@
 
   @media (min-width: $value)
 
-    .f-#{$name}-left
+    .f-left-#{$name}
       display: left
 
-    .f-#{$name}-right
+    .f-right-#{$name}
       display: right
 
-    .f-#{$name}-none
+    .f-none-#{$name}
       display: none
 
 // Cursor


### PR DESCRIPTION
This begins a pattern on the functional classes for responsiveness. By adding a suffix of `-xs`, `-sm`, `-md`, `-lg` to certain classes, it scopes them in their respective media query breakpoints. 

Reminder, the 4 breakpoints are:

``` sass
$breakpoint-xs: 480px
$breakpoint-sm: 640px
$breakpoint-md: 768px
$breakpoint-lg: 1024px
```

(which also, if you have an opinion on these i'd like to hear it. maybe having 3 would be better)

So `.d-block-sm` is:

``` sass
@media (min-width: $breakpoint-sm) // 640px
  .d-block-sm
    display-block
```

The prefix supports display, float, and max-width for now. 

@bellycard/apps 
