### PR TITLE
FIx order of imports to fix specificity issues

### DIFF
--- a/assets/stylesheets/rolodex.sass
+++ b/assets/stylesheets/rolodex.sass
@@ -26,3 +26,7 @@
 @import rolodex/components/modals
 @import rolodex/components/tables
 @import rolodex/components/tooltips
+
+// Utilities
+
+@import rolodex/settings/utilities/utilities

--- a/assets/stylesheets/rolodex/settings/_settings.sass
+++ b/assets/stylesheets/rolodex/settings/_settings.sass
@@ -25,8 +25,3 @@
 @import mixins/rems
 @import mixins/svg
 @import mixins/typography
-
-// Utilities
-// ========================================
-
-@import utilities/utilities


### PR DESCRIPTION
Small but wanted to make it known. Including the functional classes _before_ the components wouldn't work because of specificity issues. So `class="btn-boring color-blue"` would not be blue. 

By moving the utilities out of `settings/settings` and importing it after the components, we 👍 

@bellycard/apps 
