### PR TITLE
Dropdown buttons and button groups

### DIFF
--- a/assets/stylesheets/rolodex/components/_buttons.sass
+++ b/assets/stylesheets/rolodex/components/_buttons.sass
@@ -96,3 +96,59 @@
 
   &:active
     background-color: rgba($black, .7)
+
+// Dropdown buttons
+// ========================================
+
+.btn-dropdown
+  border-bottom-right-radius: 0
+  border-top-right-radius: 0
+  float: left
+
+  &.btn
+    +rem(margin-right, -2px)
+
+.btn-dropdown-menu
+  border-bottom-left-radius: 0
+  border-top-left-radius: 0
+  +rem(margin-left, 1px)
+
+// Button groups
+// ========================================
+
+.btn-group
+  display: inline-block
+  position: relative
+  vertical-align: middle
+
+  > .btn
+    position: relative
+    float: left
+
+    &.active,
+    &:active,
+    &:focus
+      z-index: 2
+
+  // Middle buttons
+
+  .btn + .btn
+    +rem(margin-left, -1px)
+
+  & > .btn:not(:first-child):not(:last-child)
+    border-radius: 0
+
+  // First button
+
+  & > .btn:first-child
+    margin-left: 0
+
+    &:not(:last-child)
+      border-bottom-right-radius: 0
+      border-top-right-radius: 0
+
+  // Last button
+
+  & > .btn:last-child:not(:first-child)
+    border-bottom-left-radius: 0
+    border-top-left-radius: 0


### PR DESCRIPTION
![screen shot 2016-08-01 at 6 01 01 pm](https://cloud.githubusercontent.com/assets/163537/17311617/5035f80c-5812-11e6-867a-42f096ab4847.png)

![screen shot 2016-08-01 at 6 02 23 pm](https://cloud.githubusercontent.com/assets/163537/17311619/50398b66-5812-11e6-9c23-1d044ab870ff.png)

![screen shot 2016-08-01 at 6 02 30 pm](https://cloud.githubusercontent.com/assets/163537/17311618/5037a1ac-5812-11e6-994e-2685426b73e9.png)

Bear with me on the dropdown, but if you're using `rolodex-angular` this is what the syntax is:

``` html
<button class="btn btn-default btn-dropdown" href="#">Edit</button>
<div class="dropdown" data-dropdown>
  <button class="btn btn-default btn-dropdown-menu" data-dropdown-toggle aria-haspopup="true" aria-expanded="false">
    <div class="i-caret-white"></div>
  </button>
  <ul class="dropdown-menu" data-dropdown-content role="menu">
    <li class="dropdown-menu-item" role="presentation">Pete</li>
    <li class="dropdown-menu-item" role="presentation">Rocks</li>
  </ul>
</div>
```

and for the button group:

``` html
<div class="btn-group">
  <a class="btn btn-boring" href="#">All</a>
  <a class="btn btn-boring" href="#">Point Adjustments</a>
  <a class="btn btn-boring" href="#">Redemptions</a>
  <a class="btn btn-boring" href="#">Purchases</a>
</div>
```

as you can see the dropdown syntax is pretty thick, but thats the nature of the javascript dropdown. any thoughts on cleaning that up? could maybe wrap everything in a parent div and key off that.

@bellycard/apps
