### PR TITLE
Add more gutters

### DIFF
--- a/assets/stylesheets/rolodex/settings/utilities/lib/_margin.sass
+++ b/assets/stylesheets/rolodex/settings/utilities/lib/_margin.sass
@@ -5,7 +5,8 @@
 
 @each $name, $value in $baselines
 
-  .m-#{$name}
+  .m-#{$name},
+  .my-#{$name}
     +rem(margin-bottom, $value)
     +rem(margin-top, $value)
 
@@ -56,14 +57,6 @@
 .mx-quarter
   +rem(margin-left, $gutter-quarter)
   +rem(margin-right, $gutter-quarter)
-
-// Bump
-
-.m-bump
-  +bump(margin, box)
-
-.m-bump-half
-  +bump(margin, baselines gutters-half)
 
 // Resets
 

--- a/assets/stylesheets/rolodex/settings/utilities/lib/_margin.sass
+++ b/assets/stylesheets/rolodex/settings/utilities/lib/_margin.sass
@@ -26,8 +26,8 @@
 .ml-third
   +rem(margin-left, $gutter-third)
 
-.ml-fourth
-  +rem(margin-left, $gutter-fourth)
+.ml-quarter
+  +rem(margin-left, $gutter-quarter)
 
 .mr
   +rem(margin-right, $gutter)
@@ -38,8 +38,8 @@
 .mr-third
   +rem(margin-right, $gutter-third)
 
-.mr-fourth
-  +rem(margin-right, $gutter-fourth)
+.mr-quarter
+  +rem(margin-right, $gutter-quarter)
 
 .mx
   +rem(margin-left, $gutter)
@@ -53,9 +53,9 @@
   +rem(margin-left, $gutter-third)
   +rem(margin-right, $gutter-third)
 
-.mx-fourth
-  +rem(margin-left, $gutter-fourth)
-  +rem(margin-right, $gutter-fourth)
+.mx-quarter
+  +rem(margin-left, $gutter-quarter)
+  +rem(margin-right, $gutter-quarter)
 
 // Bump
 

--- a/assets/stylesheets/rolodex/settings/utilities/lib/_margin.sass
+++ b/assets/stylesheets/rolodex/settings/utilities/lib/_margin.sass
@@ -42,6 +42,10 @@
 .mr-quarter
   +rem(margin-right, $gutter-quarter)
 
+.my
+  +rem(margin-bottom, $baseline-base)
+  +rem(margin-top, $baseline-base)
+
 .mx
   +rem(margin-left, $gutter)
   +rem(margin-right, $gutter)

--- a/assets/stylesheets/rolodex/settings/utilities/lib/_margin.sass
+++ b/assets/stylesheets/rolodex/settings/utilities/lib/_margin.sass
@@ -15,34 +15,54 @@
   .mb-#{$name}
     +rem(margin-bottom, $value)
 
-// Horizontal alignment ($gutter/$gutter-half)
+// Horizontal alignment ($gutters)
 
 .ml
   +rem(margin-left, $gutter)
 
-.ml-h
+.ml-half
   +rem(margin-left, $gutter-half)
+
+.ml-third
+  +rem(margin-left, $gutter-third)
+
+.ml-fourth
+  +rem(margin-left, $gutter-fourth)
 
 .mr
   +rem(margin-right, $gutter)
 
-.mr-h
+.mr-half
   +rem(margin-right, $gutter-half)
+
+.mr-third
+  +rem(margin-right, $gutter-third)
+
+.mr-fourth
+  +rem(margin-right, $gutter-fourth)
 
 .mx
   +rem(margin-left, $gutter)
   +rem(margin-right, $gutter)
 
-.mx-h
+.mx-half
   +rem(margin-left, $gutter-half)
   +rem(margin-right, $gutter-half)
+
+.mx-third
+  +rem(margin-left, $gutter-third)
+  +rem(margin-right, $gutter-third)
+
+.mx-fourth
+  +rem(margin-left, $gutter-fourth)
+  +rem(margin-right, $gutter-fourth)
 
 // Bump
 
 .m-bump
   +bump(margin, box)
 
-.m-bump-h
+.m-bump-half
   +bump(margin, baselines gutters-half)
 
 // Resets

--- a/assets/stylesheets/rolodex/settings/utilities/lib/_padding.sass
+++ b/assets/stylesheets/rolodex/settings/utilities/lib/_padding.sass
@@ -42,6 +42,10 @@
 .pr-quarter
   +rem(padding-right, $gutter-quarter)
 
+.py
+  +rem(padding-bottom, $baseline-base)
+  +rem(padding-top, $baseilne-base)
+
 .px
   +rem(padding-left, $gutter)
   +rem(padding-right, $gutter)

--- a/assets/stylesheets/rolodex/settings/utilities/lib/_padding.sass
+++ b/assets/stylesheets/rolodex/settings/utilities/lib/_padding.sass
@@ -15,34 +15,54 @@
   .pb-#{$name}
     +rem(padding-bottom, $value)
 
-// Horizontal alignment ($gutter/$gutter-half)
+// Horizontal alignment ($gutters)
 
 .pl
   +rem(padding-left, $gutter)
 
-.pl-h
+.pl-half
   +rem(padding-left, $gutter-half)
+
+.pl-third
+  +rem(padding-left, $gutter-third)
+
+.pl-fourth
+  +rem(padding-left, $gutter-fourth)
 
 .pr
   +rem(padding-right, $gutter)
 
-.pr-h
+.pr-half
   +rem(padding-right, $gutter-half)
+
+.pr-third
+  +rem(padding-right, $gutter-third)
+
+.pr-fourth
+  +rem(padding-right, $gutter-fourth)
 
 .px
   +rem(padding-left, $gutter)
   +rem(padding-right, $gutter)
 
-.px-h
+.px-half
   +rem(padding-left, $gutter-half)
   +rem(padding-right, $gutter-half)
+
+.px-third
+  +rem(padding-left, $gutter-third)
+  +rem(padding-right, $gutter-third)
+
+.px-fourth
+  +rem(padding-left, $gutter-fourth)
+  +rem(padding-right, $gutter-fourth)
 
 // Bump
 
 .p-bump
   +bump(padding, box)
 
-.p-bump-h
+.p-bump-half
   +bump(padding, baselines gutters-half)
 
 // Resets

--- a/assets/stylesheets/rolodex/settings/utilities/lib/_padding.sass
+++ b/assets/stylesheets/rolodex/settings/utilities/lib/_padding.sass
@@ -26,8 +26,8 @@
 .pl-third
   +rem(padding-left, $gutter-third)
 
-.pl-fourth
-  +rem(padding-left, $gutter-fourth)
+.pl-quarter
+  +rem(padding-left, $gutter-quarter)
 
 .pr
   +rem(padding-right, $gutter)
@@ -38,8 +38,8 @@
 .pr-third
   +rem(padding-right, $gutter-third)
 
-.pr-fourth
-  +rem(padding-right, $gutter-fourth)
+.pr-quarter
+  +rem(padding-right, $gutter-quarter)
 
 .px
   +rem(padding-left, $gutter)
@@ -53,9 +53,9 @@
   +rem(padding-left, $gutter-third)
   +rem(padding-right, $gutter-third)
 
-.px-fourth
-  +rem(padding-left, $gutter-fourth)
-  +rem(padding-right, $gutter-fourth)
+.px-quarter
+  +rem(padding-left, $gutter-quarter)
+  +rem(padding-right, $gutter-quarter)
 
 // Bump
 

--- a/assets/stylesheets/rolodex/settings/utilities/lib/_padding.sass
+++ b/assets/stylesheets/rolodex/settings/utilities/lib/_padding.sass
@@ -5,7 +5,8 @@
 
 @each $name, $value in $baselines
 
-  .p-#{$name}
+  .p-#{$name},
+  .py-#{$name}
     +rem(padding-bottom, $value)
     +rem(padding-top, $value)
 
@@ -56,14 +57,6 @@
 .px-quarter
   +rem(padding-left, $gutter-quarter)
   +rem(padding-right, $gutter-quarter)
-
-// Bump
-
-.p-bump
-  +bump(padding, box)
-
-.p-bump-half
-  +bump(padding, baselines gutters-half)
 
 // Resets
 

--- a/assets/stylesheets/rolodex/settings/variables/_layout.scss
+++ b/assets/stylesheets/rolodex/settings/variables/_layout.scss
@@ -3,8 +3,10 @@
 
 // Gutters
 
-$gutter:      30px;
-$gutter-half: $gutter / 2;
+$gutter:          30px;
+$gutter-half:     $gutter / 2;
+$gutter-third:    $gutter / 3;
+$gutter-quarter:  $gutter / 4;
 
 // Baselines
 


### PR DESCRIPTION
When using the functional classes, I find myself wanting to bump stuff left/right 5px/10px. so I added:

``` sass
$gutter:           30px;
$gutter-half:      $gutter / 2;    // 15px
$gutter-third:     $gutter / 3;    // 10px
$gutter-quarter:   $gutter / 4;    // 7.5px
```

⚠️  this PR changes any functional classes from `-h` (for $gutter-half) to `-half` (.mx-h, .pl-h, .p-bump-h). it's more consistent with our naming convention, not sure why i did it in the first place. sorry.

so now we also have `-third` and `-quarter` for horizontal alignment on margin/padding:

examples:

``` sass
.mx-half     // margin-left: $gutter-half; margin-right: $gutter-half
.mr-third    // margin-right: $gutter-third
.pl-quarter  // margin-left: $gutter-quarter
.m-bump-half // margin: $baseline-base $gutter-half
```

if you have any better idea for a naming convention im all ears.

> note i didnt add `-third` or `-quarter` to the `bump` helper. thats because we should always bump columns using $gutter (`-bump`) and $gutter-half (`-bump-half`)

@bellycard/apps 
