### PR TITLE
Don't assume autoprefixer...

### DIFF
--- a/assets/stylesheets/rolodex/components/forms/_reset.sass
+++ b/assets/stylesheets/rolodex/components/forms/_reset.sass
@@ -29,9 +29,8 @@ input[type="search"]
 
 input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-decoration,
-  -webkit-appearance: none
-
 input[type="submit"]
+  -webkit-appearance: none
   appearance: none
 
 button,


### PR DESCRIPTION
@bellycard/apps 

Noticed this weird bug that I thought was addressed when deploying the enterprise admin. If you don't use autoprefixer or something like it, then the proper cross browser css isn't generated and we get the behavior below. This should address any issues with people using rolodex and, for whatever reason, NOT using parser to generate vendor prefixes.

![slack for ios upload-2](https://cloud.githubusercontent.com/assets/1316075/17589413/4d4a660c-5f9a-11e6-8d5c-929d31535e56.jpg)
