### PR TITLE
CSS :target modals and responsiveness

### DIFF
--- a/assets/stylesheets/rolodex/components/_buttons.sass
+++ b/assets/stylesheets/rolodex/components/_buttons.sass
@@ -60,7 +60,12 @@
       background-color: $bg-active
 
   .btn-#{$kind}-raised
-    box-shadow: inset 0 -2px rgba(0,0,0,0.20)
+
+    @if $kind == "boring"
+      box-shadow: inset 0 -1px rgba(0,0,0,0.20)
+    @else
+      box-shadow: inset 0 -2px rgba(0,0,0,0.20)
+
     border: 0
 
     &:active

--- a/assets/stylesheets/rolodex/components/_modals.sass
+++ b/assets/stylesheets/rolodex/components/_modals.sass
@@ -1,6 +1,9 @@
 // Modals
 // ========================================
 
+$modal-width: 660px !default
+$modal-breakpoint: $breakpoint-md + 1 !default
+
 .modal
   background-color: rgba($slate-dark, .8)
   bottom: 0
@@ -8,26 +11,40 @@
   opacity: 0
   overflow-x: hidden
   overflow-y: auto
-  +rem(padding, $baseline-step * 10)
+  pointer-events: none
   position: fixed
   right: 0
   top: 0
   transition: $transition-all
   z-index: 99
 
+  &:target
+    opacity: 1
+    pointer-events: all
+
+  @media (min-width: $modal-breakpoint)
+    +rem(padding, $baseline-step * 10 $gutter)
+
 .modal-fade
   opacity: 1
+  pointer-events: all
 
 .modal-content
   background-color: $white
-  +rem(border-radius, $border-radius-base)
-  +rem(box-shadow, 0 0 0 4px rgba($black, .15))
   margin: 0 auto
-  +rem(max-width, 660px)
+
+  @media (min-width: $modal-breakpoint)
+    +rem(border-radius, $border-radius-base)
+    +rem(box-shadow, 0 0 0 4px rgba($black, .15))
+    +rem(max-width, $modal-width)
+    transform: translate(0,0)
 
 .modal-header,
 .modal-footer
-  +bump(padding, box)
+  +bump(padding, baselines-x-small gutters-half)
+  
+  @media (min-width: $modal-breakpoint)
+    +bump(padding, box)
 
 .modal-header
   position: relative
@@ -48,7 +65,10 @@
   +rem(border-width, 1px 0)
 
 .modal-body
-  +rem(padding, ($baseline-base - 1) $gutter)
+  +bump(padding, baselines gutters-half)
+
+  @media (min-width: $modal-breakpoint)
+    +rem(padding, ($baseline-base - 1) $gutter)
 
   p:last-child
     margin-bottom: 0
@@ -81,3 +101,12 @@
       border-color: $blue
       color: $black
       cursor: default
+
+.modal-close
+  content: ''
+  position: absolute
+  top: 0
+  right: 0
+  bottom: 0
+  left: 0
+  z-index: 0

--- a/assets/stylesheets/rolodex/components/_modals.sass
+++ b/assets/stylesheets/rolodex/components/_modals.sass
@@ -18,14 +18,11 @@ $modal-breakpoint: $breakpoint-md + 1 !default
   transition: $transition-all
   z-index: 99
 
-  &:target
-    opacity: 1
-    pointer-events: all
-
   @media (min-width: $modal-breakpoint)
     +rem(padding, $baseline-step * 10 $gutter)
 
 .modal-fade
+.modal:target
   opacity: 1
   pointer-events: all
 

--- a/assets/stylesheets/rolodex/settings/variables/_layout.scss
+++ b/assets/stylesheets/rolodex/settings/variables/_layout.scss
@@ -30,8 +30,8 @@ $baselines: (
 
 // Border radius
 
-$border-radius-base: 6px;
-$border-radius-mini: 4px;
+$border-radius-base: 6px !default;
+$border-radius-mini: 4px !default;
 
 // Breakpoints
 


### PR DESCRIPTION
Same html as before, but to show a modal without javascript we can utilize the `:target` functionality. So:

``` html
<a href="#modal">Show</a>
```

``` html
<div id="modal" class="modal">
  <a class="modal-close" href="#"></a> <!-- NOTE BELOW -->

  <div class="modal-content">
    <div class="modal-header">
      <a class="i-close" href="#">&times;</a>
      <div class="modal-title">Modal</div>
    </div>

    <div class="modal-body">
    </div>

    <div class="modal-footer clear">
      <a class="btn btn-boring pull-right" href="#">Close</a>
    </div>
  </div>
</div>
```

The only new thing to use modals without javascript is to add the `modal-close` class. This allows us to close the modal (by setting href="#") when clicking the modal backdrop.

The modals now fit the full screen in < 768px. 

@bellycard/apps 
