### PR TITLE
Firefox bugfixes

### DIFF
--- a/assets/stylesheets/rolodex/components/forms/_inputs.sass
+++ b/assets/stylesheets/rolodex/components/forms/_inputs.sass
@@ -10,6 +10,7 @@
   +rem(border-radius, $border-radius-base)
   color: $black-offset
   display: block
+  +rem(line-height, $baseline-base)
   +rem(padding, ($baseline-step + 2) ($gutter-half - 1))
   position: relative
   transition: border .15s ease, background-image .15s ease
@@ -29,6 +30,7 @@
 
   &:-ms-input-placeholder,
   &:-moz-placeholder,
+  &::-moz-placeholder,
   &::-webkit-input-placeholder
     color: $gray
 


### PR DESCRIPTION
@bellycard/apps 

Related Trello Card: https://trello.com/c/CDnR0xXn/19-search-button-height-in-firefox

<img width="484" alt="screen shot 2016-08-26 at 10 47 44 am" src="https://cloud.githubusercontent.com/assets/1316075/18011940/d8a0019c-6b7c-11e6-808e-c607e7a644e1.png">

TIL that firefox sets the line-height of their inputs to `normal`. Even worse, they were applying `!important` making it impossible for authors to override.  For reference:
- https://bugzilla.mozilla.org/show_bug.cgi?id=697451
- http://stackoverflow.com/questions/7229568/input-height-differences-in-firefox-and-chrome

Fortunately, it looks like they've removed the `!important` declaration allowing me to set the line-height. Kinda lame.  I'm open to other suggestions, but this did fix it for me locally. 

Also, I noticed that the placeholder text on inputs in firefox wasn't getting our default `$gray` color so I fixed that as well.

<img width="469" alt="screen shot 2016-08-26 at 10 46 46 am" src="https://cloud.githubusercontent.com/assets/1316075/18011970/fad6374a-6b7c-11e6-83f5-2f19c5586ac3.png">
