### PR TITLE
Adds file size to build output

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,7 @@ var paths = {
   dist: 'assets/dist', // where compiled files will go
 }
 
-// Compiles coffee to js, annotates Angular dependencies
+// Compiles sass to css
 gulp.task('sass', function(callback) {
   return gulp.src(path.join(paths.assets, paths.stylesheets, '**/*.{sass,scss}'))
     .pipe($.sass())
@@ -59,5 +59,25 @@ gulp.task('js', ['coffee', 'templates'], function(callback) {
     })
 });
 
-gulp.task('build', ['sass', 'js']);
+gulp.task('assetSize', function(callback) {
+  return gulp.src(paths.dist + '**/*.{css,js}')
+    .pipe($.size({
+      title: 'Output...',
+      showFiles: true,
+    }));
+});
+
+gulp.task('assetSizeGzip', function(callback) {
+  return gulp.src(paths.dist + '**/*.{css,js}')
+    .pipe($.size({
+      title: 'Gzipped Output...',
+      gzip: true,
+      showFiles: true,
+    }));
+});
+
+gulp.task('build', function(callback) {
+  $.runSequence(['sass', 'js'], 'assetSize', 'assetSizeGzip', callback);
+});
+
 gulp.task('default', ['build']);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "gulp-load-plugins": "^1.0.0-rc.1",
     "gulp-ng-annotate": "^1.1.0",
     "gulp-rename": "^1.2.2",
+    "gulp-run-sequence": "^0.3.2",
     "gulp-sass": "^2.3.2",
+    "gulp-size": "^2.1.0",
     "gulp-uglify": "^1.4.1"
   }
 }


### PR DESCRIPTION
@bellycard/apps 

Updates `$ gulp build` output to include both the minified and gzipped file size of rolodex assets.

![screen shot 2016-09-26 at 2 11 17 pm](https://cloud.githubusercontent.com/assets/1316075/18848288/3952a132-83f3-11e6-83b2-63d56c39f7ad.png)
