### PR TITLE
Italic class fix

### DIFF
--- a/assets/stylesheets/rolodex/settings/utilities/lib/_typography.sass
+++ b/assets/stylesheets/rolodex/settings/utilities/lib/_typography.sass
@@ -21,6 +21,11 @@
 .fw-600
   font-weight: 600
 
+// Font styles
+
+.fs-italic
+  font-style: italic
+
 // Text alignment
 
 .ta-center
@@ -33,9 +38,6 @@
   text-align: right
 
 // Text decoration
-
-.td-italic
-  text-decoration: italic
 
 .td-underline
   text-decoration: underline


### PR DESCRIPTION
@bellycard/enterprise-admin 

Uses the correct property for `italic`
