### PR TITLE
Better buttons

### DIFF
--- a/assets/stylesheets/rolodex/components/_buttons.sass
+++ b/assets/stylesheets/rolodex/components/_buttons.sass
@@ -103,7 +103,7 @@
 // Gradient
 
 .btn-gradient
-  background-image: linear-gradient(-180deg, rgba(255,255,255,0.00) 0%, rgba(0,0,0,0.20) 100%)
+  background-image: linear-gradient(-180deg, rgba(255, 255, 255, 0) 0%, rgba(0, 0, 0, .2) 100%)
   box-shadow: none
   border: none
 

--- a/assets/stylesheets/rolodex/components/_buttons.sass
+++ b/assets/stylesheets/rolodex/components/_buttons.sass
@@ -125,18 +125,23 @@
 
 // Button groups
 // ========================================
-$btn-group-bg: $white !default
-$btn-group-color: $blue-slate-medium !default
 
-$btn-group-border-color: $gray-alt !default
+// Button group settings
+
+$btn-group-bg: $white !default
+$btn-group-color: $gray !default
+
+$btn-group-border-color: $gray-light !default
 $btn-group-border-style: solid
 $btn-group-border-width: 1px
 
-$btn-group-hover-bg: $gray-light-alt !default
-$btn-group-hover-color: $blue-dark !default
+$btn-group-hover-bg: $white-offset !default
+$btn-group-hover-color: $black-offset !default
 
-$btn-group-active-bg: $blue-dark !default
-$btn-group-active-color: $white !default
+$btn-group-active-bg: $white-offset !default
+$btn-group-active-color: $black-offset !default
+
+// Button group
 
 .btn-group
   display: inline-block
@@ -156,7 +161,6 @@ $btn-group-active-color: $white !default
 
       &.active
         background-color: $btn-group-active-bg
-        background-image: linear-gradient(-180deg, rgba(255, 255, 255, 0) 0%, rgba(0, 0, 0, .2) 100%)
         border-color: $btn-group-active-bg
         color: $btn-group-active-color
 

--- a/assets/stylesheets/rolodex/components/_buttons.sass
+++ b/assets/stylesheets/rolodex/components/_buttons.sass
@@ -64,7 +64,7 @@
   color: $blue
 
 .btn-boring.btn-gradient
-  background-image: linear-gradient(-180deg, #FFFFFF 0%, #F3F5F7 100%)
+  background-image: linear-gradient(-180deg, #fff 0%, #f3f5f7 100%)
 
 // Alternate, Overlay, & Gradient
 // ========================================
@@ -127,11 +127,14 @@
 // ========================================
 $btn-group-bg: $white !default
 $btn-group-color: $blue-slate-medium !default
+
 $btn-group-border-color: $gray-alt !default
 $btn-group-border-style: solid
 $btn-group-border-width: 1px
+
 $btn-group-hover-bg: $gray-light-alt !default
 $btn-group-hover-color: $blue-dark !default
+
 $btn-group-active-bg: $blue-dark !default
 $btn-group-active-color: $white !default
 
@@ -151,14 +154,15 @@ $btn-group-active-color: $white !default
       +rem(border-width, $btn-group-border-width)
       color: $btn-group-color
 
+      &.active
+        background-color: $btn-group-active-bg
+        background-image: linear-gradient(-180deg, rgba(255, 255, 255, 0) 0%, rgba(0, 0, 0, .2) 100%)
+        border-color: $btn-group-active-bg
+        color: $btn-group-active-color
+
       &:hover
         background-color: $btn-group-hover-bg
         color: $btn-group-hover-color
-
-      &.active
-        background-color: $btn-group-active-bg
-        background-image: linear-gradient(-180deg, rgba(255,255,255,0.00) 0%, rgba(0,0,0,0.20) 100%)
-        color: $btn-group-active-color
 
     &.active,
     &:active,

--- a/assets/stylesheets/rolodex/components/_buttons.sass
+++ b/assets/stylesheets/rolodex/components/_buttons.sass
@@ -64,7 +64,8 @@
   color: $blue
 
 .btn-boring.btn-gradient
-  background-image: linear-gradient(-180deg, #fff 0%, #f3f5f7 100%)
+  background-image: linear-gradient(-180deg, #fff 50%, #f3f5f7 100%)
+  +rem(border, 1px solid $gray-light)
 
 // Alternate, Overlay, & Gradient
 // ========================================
@@ -103,7 +104,7 @@
 // Gradient
 
 .btn-gradient
-  background-image: linear-gradient(-180deg, rgba(255, 255, 255, 0) 0%, rgba(0, 0, 0, .2) 100%)
+  background-image: linear-gradient(-180deg, rgba(255, 255, 255, 0) 50%, rgba(0, 0, 0, .2) 100%)
   box-shadow: none
   border: none
 

--- a/assets/stylesheets/rolodex/components/_buttons.sass
+++ b/assets/stylesheets/rolodex/components/_buttons.sass
@@ -59,23 +59,11 @@
     &:active
       background-color: $bg-active
 
-  .btn-#{$kind}-raised
-
-    @if $kind == "boring"
-      box-shadow: inset 0 -1px rgba(0,0,0,0.20)
-    @else
-      box-shadow: inset 0 -2px rgba(0,0,0,0.20)
-
-    border: 0
-
-    &:active
-      box-shadow: inset 0 0 rgba(0,0,0,0.20)
-
 .btn-boring:hover,
 .btn-boring:active
   color: $blue
 
-// Alternate & Overlay
+// Alternate, Overlay, & Gradient
 // ========================================
 
 .btn-alt,
@@ -108,6 +96,13 @@
 
   &:active
     background-color: rgba($black, .7)
+
+// Gradient
+
+.btn-gradient
+  background-image: linear-gradient(-180deg, rgba(255,255,255,0.00) 0%, rgba(0,0,0,0.20) 100%)
+  box-shadow: none
+  border: none
 
 // Dropdown buttons
 // ========================================

--- a/assets/stylesheets/rolodex/components/_buttons.sass
+++ b/assets/stylesheets/rolodex/components/_buttons.sass
@@ -63,6 +63,9 @@
 .btn-boring:active
   color: $blue
 
+.btn-boring.btn-gradient
+  background-image: linear-gradient(-180deg, #FFFFFF 0%, #F3F5F7 100%)
+
 // Alternate, Overlay, & Gradient
 // ========================================
 
@@ -122,6 +125,15 @@
 
 // Button groups
 // ========================================
+$btn-group-bg: $white !default
+$btn-group-color: $blue-slate-medium !default
+$btn-group-border-color: $gray-alt !default
+$btn-group-border-style: solid
+$btn-group-border-width: 1px
+$btn-group-hover-bg: $gray-light-alt !default
+$btn-group-hover-color: $blue-dark !default
+$btn-group-active-bg: $blue-dark !default
+$btn-group-active-color: $white !default
 
 .btn-group
   display: inline-block
@@ -131,6 +143,22 @@
   > .btn
     position: relative
     float: left
+
+    &.btn-style
+      background-color: $btn-group-bg
+      border-color: $btn-group-border-color
+      border-style: $btn-group-border-style
+      +rem(border-width, $btn-group-border-width)
+      color: $btn-group-color
+
+      &:hover
+        background-color: $btn-group-hover-bg
+        color: $btn-group-hover-color
+
+      &.active
+        background-color: $btn-group-active-bg
+        background-image: linear-gradient(-180deg, rgba(255,255,255,0.00) 0%, rgba(0,0,0,0.20) 100%)
+        color: $btn-group-active-color
 
     &.active,
     &:active,


### PR DESCRIPTION
cc @joeysalvador @brousalis @shayhowe 

- removes inset buttons option
- adds `btn-gradient` class
- adds default `btn-group` styles 

Pete and I discussed different approaches and decided a `.btn-gradient` class would not only be more functional, but would also be more flexible.

Also, Joey, mentioned that there may be situations where we want to use both gradient and non gradient options within the same app, so adding a flag to override default button styles with a gradient background would break down. If you disagree, I'm open for debate!

Worth noting, once this is merged, we'll need to add the `.btn-gradient` class to all `.btn` instances within enterprise admin.

<hr>

![screen shot 2016-11-03 at 4 28 57 pm](https://cloud.githubusercontent.com/assets/1316075/19985881/a87c544c-a1e2-11e6-96f1-5f1fea19b189.png)

<hr>

![screen shot 2016-11-03 at 3 54 49 pm](https://cloud.githubusercontent.com/assets/1316075/19984919/5ed91aa4-a1de-11e6-994d-9ee6f440a079.png)
