### PR TITLE
uses box shadow instead of border

### DIFF
--- a/assets/stylesheets/rolodex/components/_buttons.sass
+++ b/assets/stylesheets/rolodex/components/_buttons.sass
@@ -43,6 +43,7 @@
 
 // Kinds
 // ========================================
+$btn-boring-border: $gray-light !default
 
 @each $kind, $bg-normal, $bg-hover, $bg-active in $btns
 
@@ -50,7 +51,7 @@
     background-color: $bg-normal
 
     @if $kind == "boring"
-      border-color: $gray-light
+      border-color: $btn-boring-border
       color: $gray-dark
 
     &:hover
@@ -65,7 +66,7 @@
 
 .btn-boring.btn-gradient
   background-image: linear-gradient(-180deg, #fff 50%, #f3f5f7 100%)
-  +rem(border, 1px solid $gray-light)
+  border-color: $btn-boring-border
 
 // Alternate, Overlay, & Gradient
 // ========================================
@@ -131,14 +132,9 @@
 
 $btn-group-bg: $white !default
 $btn-group-color: $gray !default
-
 $btn-group-border-color: $gray-light !default
-$btn-group-border-style: solid
-$btn-group-border-width: 1px
-
 $btn-group-hover-bg: $white-offset !default
 $btn-group-hover-color: $black-offset !default
-
 $btn-group-active-bg: $white-offset !default
 $btn-group-active-color: $black-offset !default
 $btn-group-active-border: $white-offset !default
@@ -151,19 +147,22 @@ $btn-group-active-border: $white-offset !default
   vertical-align: middle
 
   > .btn
+    // using box-shadow instead of borders to accommodate gradient backgrounds
+    // this adds 1px padding so they match buttons with borders
+    // https://github.com/bellycard/rolodex/blob/master/assets/stylesheets/rolodex/components/_buttons.sass#L15
+    +rem(padding-bottom, 9px)
+    +rem(padding-top, 9px)
     position: relative
     float: left
 
     &.btn-style
       background-color: $btn-group-bg
-      border-color: $btn-group-border-color
-      border-style: $btn-group-border-style
-      +rem(border-width, $btn-group-border-width)
+      +rem(box-shadow, inset 0 0 0 1px $btn-group-border-color)
+      border: 0
       color: $btn-group-color
 
       &.active
         background-color: $btn-group-active-bg
-        border-color: $btn-group-active-border
         color: $btn-group-active-color
 
       &:hover

--- a/assets/stylesheets/rolodex/components/_buttons.sass
+++ b/assets/stylesheets/rolodex/components/_buttons.sass
@@ -157,8 +157,8 @@ $btn-group-active-border: $white-offset !default
 
     &.btn-style
       background-color: $btn-group-bg
-      +rem(box-shadow, inset 0 0 0 1px $btn-group-border-color)
       border: 0
+      +rem(box-shadow, inset 0 0 0 1px $btn-group-border-color)
       color: $btn-group-color
 
       &.active


### PR DESCRIPTION
cc @brousalis @shayhowe 

Using `box-shadow` instead of `border` for the button groups to accommodate gradient backgrounds. 

![screen shot 2016-11-07 at 3 24 46 pm](https://cloud.githubusercontent.com/assets/1316075/20076525/5af53fc6-a4fe-11e6-91c6-8bf37c3e9add.png)